### PR TITLE
Add ayoajayi-hmcts Slack mapping

### DIFF
--- a/slack.json
+++ b/slack.json
@@ -4351,6 +4351,10 @@
     {
       "github": "ChandraHMCTS",
       "slack": "U081NUJPRKR"
+    },
+    {
+      "github": "ayoajayi-hmcts",
+      "slack": "U0BG58SLD4M"
     }
 
   ]


### PR DESCRIPTION
Adds the GitHub to Slack mapping for ayoajayi-hmcts (Slack member ID U0BG58SLD4M) so Jenkins build notifications reach me. Onboarding task HDPI-7850.